### PR TITLE
Fix error when writing strings in two consecutive lines

### DIFF
--- a/01-variables/03-strings.jl
+++ b/01-variables/03-strings.jl
@@ -2,6 +2,7 @@ include("02-booleans.jl")
 
 # Strings are created with double quotes
 "Hello, world!"
+
 'Hello, world!' # Watch out: single quotes are reserved for Chars
 'A'
 'B'
@@ -28,6 +29,7 @@ greeting*", "*name # Watch out: + doesn't work
 
 ### Tip: you can place more complicated expressions inside of $()
 "One plus two is equal to $(1 + 2)"
+
 "One plus two is equal to $(abs(-4) - 1)" # Using functions (abs for absolute value)
 
 # Pattern matching


### PR DESCRIPTION
From what we saw in this week's workshop, defining strings in two consecutive lines will produce an error because Julia thinks that we are trying to write documentation. For example, running

```julia
"Hello, world!"
"Hello, world!"
```
Will produce an error saying: `ERROR: LoadError: cannot document the following expression: "Hello, world!"`.

I added new lines where this happens to avoid getting this error and having to comment out parts of the code in the workshop.