### PR TITLE
Add formatting configuration and apply it

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,2 @@
+indent = 2
+format_docstrings = true

--- a/01-variables/01-numeric.jl
+++ b/01-variables/01-numeric.jl
@@ -29,8 +29,8 @@ typeof(one_float)
 x + y # Addition
 x - y # Subtraction
 x + one # Can mix integers and floats
-x*y # Multiplication
-x/2 # Division
+x * y # Multiplication
+x / 2 # Division
 x^2 # Exponentiation
 (1 + 2)^3 * 2 + 1 # evaluated in PEMDAS order
 
@@ -39,5 +39,5 @@ sqrt(2)
 √2
 
 ## Other numeric types
-5//37 # Rational
+5 // 37 # Rational
 1 + 2im # Complex

--- a/01-variables/02-booleans.jl
+++ b/01-variables/02-booleans.jl
@@ -22,4 +22,4 @@ true && false
 # Tip: boolean values can be used for math (true = 1, false = 0)
 true + true
 one + true
-(x > 6)*x
+(x > 6) * x

--- a/01-variables/03-strings.jl
+++ b/01-variables/03-strings.jl
@@ -3,7 +3,7 @@ include("02-booleans.jl")
 # Strings are created with double quotes
 "Hello, world!"
 
-# 'Hello, world!' # Watch out: single quotes are reserved for Chars
+'Hello, world!' # Watch out: single quotes are reserved for Chars
 'A'
 'B'
 

--- a/01-variables/03-strings.jl
+++ b/01-variables/03-strings.jl
@@ -3,7 +3,7 @@ include("02-booleans.jl")
 # Strings are created with double quotes
 "Hello, world!"
 
-'Hello, world!' # Watch out: single quotes are reserved for Chars
+# 'Hello, world!' # Watch out: single quotes are reserved for Chars
 'A'
 'B'
 
@@ -22,7 +22,7 @@ name = "Jake"
 string(greeting, ", ", name)
 
 ## using * (same as multiplication)
-greeting*", "*name # Watch out: + doesn't work
+greeting * ", " * name # Watch out: + doesn't work
 
 ## Interpolation
 "$greeting, $name"

--- a/01-variables/04-containers.jl
+++ b/01-variables/04-containers.jl
@@ -7,9 +7,11 @@ mixed = [1, "one", 2, "two"]
 
 # Matrices
 ## Multi-line syntax (using line breaks)
-A = [1 2 3
-     4 5 6
-     7 8 9]
+A = [
+  1 2 3
+  4 5 6
+  7 8 9
+]
 
 ## Single line syntax (using ;)
 A2 = [1 2 3; 4 5 6; 7 8 9]
@@ -40,11 +42,7 @@ A[begin:end, begin:2] # Get all rows, but only the first two columns
 height = Dict([("Alice", 165), ("Bob", 178), ("Charlie", 172)])
 
 ## Pair syntax key => value
-height = Dict(
-    "Alice" => 165,
-    "Bob" => 178,
-    "Charlie" => 172
-)
+height = Dict("Alice" => 165, "Bob" => 178, "Charlie" => 172)
 
 ## Retrieving values
 height["Bob"] # Get Bob's height

--- a/02-syntax/01-conditionals.jl
+++ b/02-syntax/01-conditionals.jl
@@ -6,11 +6,11 @@ y = 2
 
 # Created with the if-elseif-else keywords
 if x < y # Checks if x is less than y
-    println("x is less than y")
+  println("x is less than y")
 elseif x > y # If x is not less than y, checks if it is greater than y
-    println("x is greater than y")
+  println("x is greater than y")
 else # If none of the above are true
-    println("x is equal to y")
+  println("x is equal to y")
 end # Watch out: don't forget to add the end keyword
 
 ## Try it again
@@ -21,12 +21,12 @@ x = 2
 a = 12.5
 
 if a < 5
-    message = "a is less than 5" # You can do anything inside the if-elseif-else blocks
+  message = "a is less than 5" # You can do anything inside the if-elseif-else blocks
 elseif a < 10 # Equivalent to 5 < x < 10
-    message = "a is less than 10, but greater than 5"
+  message = "a is less than 10, but greater than 5"
 elseif a < 15
-    message = "a is less than 15, but greater than 10"
-# You don't necessarily have to include else (or elseif)
+  message = "a is less than 15, but greater than 10"
+  # You don't necessarily have to include else (or elseif)
 end
 
 println(message)

--- a/02-syntax/02-loops.jl
+++ b/02-syntax/02-loops.jl
@@ -5,25 +5,25 @@ numbers = 1:10 # Range (all numbers from 1 to 10)
 
 ## Print all numbers from 1 to 10
 for number in numbers
-    println(number)
+  println(number)
 end # Don't forget to add end
 
 ## Tip: you can include any expression inside the loop
 ### For + conditionals
 for number in numbers
-    if iseven(number)
-        println("$number is even") # String interpolation
-    else
-        println("$number is odd")
-    end
+  if iseven(number)
+    println("$number is even") # String interpolation
+  else
+    println("$number is odd")
+  end
 end # Double end: one for the loop and another one for the conditionals
 
 # While loops
 ## Same example as before
 counter = 1
 while counter <= 10 # Will execute as long as our counter is less than or equal to 10
-    println(counter)
-    global counter = counter + 1 # Update global variable counter
+  println(counter)
+  global counter = counter + 1 # Update global variable counter
 end
 
 ## Can be very convenient when you don't necessarily have to go through every instance
@@ -33,7 +33,7 @@ friend = "Alice"
 
 friend_index = 1
 while names[friend_index] != friend
-    global friend_index += 1 # Shorthand notation to add 1 to friend_index
+  global friend_index += 1 # Shorthand notation to add 1 to friend_index
 end
 
 println("$friend is in the position number $friend_index of the list")
@@ -41,17 +41,17 @@ names[friend_index] # We didn't have to go through the entire list
 
 ### Same result using for + conditional + break
 for index in eachindex(names) # eachindex => get all indices associated to a vector
-    if names[index] == friend
-        println("$(names[index]) is the position number $index of the list")
-        break # Exits the loop
-    end
+  if names[index] == friend
+    println("$(names[index]) is the position number $index of the list")
+    break # Exits the loop
+  end
 end # Avoid infinte loops
 
 # Array comprehensions
 ## Powerful way to create arrays using for loops
-x = [i for i in 1:10]
-x2 = [2i for i in 1:10]
+x = [i for i = 1:10]
+x2 = [2i for i = 1:10]
 greetings = ["Hello, $name" for name in names]
 
 ## Tip: you can add conditional statements in comprehensions
-even_numbers = [i for i in 1:10 if iseven(i)]
+even_numbers = [i for i = 1:10 if iseven(i)]

--- a/02-syntax/03-assignments.jl
+++ b/02-syntax/03-assignments.jl
@@ -11,11 +11,7 @@ end
 x
 
 ### Single line
-x = begin
-  a = 3
-  b = 2
-  a + b
-end # Not as readable, but more concise
+x = begin a = 3; b = 2; a + b end # Not as readable, but more concise
 
 ## (;) syntax
 x = (a = 3; b = 2; a + b)

--- a/02-syntax/03-assignments.jl
+++ b/02-syntax/03-assignments.jl
@@ -3,15 +3,19 @@
 
 ### Multiple lines (probably the best one)
 x = begin
-    a = 3
-    b = 2
-    a + b
+  a = 3
+  b = 2
+  a + b
 end
 
 x
 
 ### Single line
-x = begin a = 3; b = 2; a + b end # Not as readable, but more concise
+x = begin
+  a = 3
+  b = 2
+  a + b
+end # Not as readable, but more concise
 
 ## (;) syntax
 x = (a = 3; b = 2; a + b)
@@ -20,20 +24,20 @@ x = (a = 3; b = 2; a + b)
 ## Global scope (accesible everywhere)
 c = 2
 
-for i in 1:5
-    println("Printing $c for the $(i)th time") # We can use x inside the for loop
+for i = 1:5
+  println("Printing $c for the $(i)th time") # We can use x inside the for loop
 end
 
 j = 1
 while j <= 10
-    println(j)
-    global j += 1 # global lets us make sure that we are modifying the loop counter
+  println(j)
+  global j += 1 # global lets us make sure that we are modifying the loop counter
 end
 
 ## Local scope
-for i in 1:5
-    local d = 3
-    println("$c + $d = $(c + d)")
+for i = 1:5
+  local d = 3
+  println("$c + $d = $(c + d)")
 end
 
 d # doesn't exist

--- a/02-syntax/05-macros.jl
+++ b/02-syntax/05-macros.jl
@@ -3,8 +3,7 @@
 # Macros start with @
 @time
 @show
-@doc
-@macroexpand
+@doc@macroexpand
 
 # Using macros
 
@@ -12,9 +11,9 @@
 @time 3 + 2 # shows you how long it takes Julia to calculate 3 + 2
 
 @time begin # time multiple expressions
-    3 + 2
-    6*5
-    4 + 2^6 - 10
+  3 + 2
+  6 * 5
+  4 + 2^6 - 10
 end
 
 @doc println # pulls documentation

--- a/02-syntax/05-macros.jl
+++ b/02-syntax/05-macros.jl
@@ -3,7 +3,7 @@
 # Macros start with @
 @time
 @show
-@doc@macroexpand
+@macroexpand
 
 # Using macros
 

--- a/03-functions/01-syntax.jl
+++ b/03-functions/01-syntax.jl
@@ -3,7 +3,7 @@
 
 ## Multiple lines syntax
 function geo_mean(values) # function name(args)
-    prod(values)^(1/length(values)) # Manipulate args
+  prod(values)^(1 / length(values)) # Manipulate args
 end # Watch out: end is required
 
 geo_mean(1:10)
@@ -16,10 +16,10 @@ geomean(1:10)
 ### Multiple arguments
 function terminal_slope(times, observations) # Here we have two arguments, and we could add more by separating them with commas 
 
-    dy = observations[end] - observations[end-2] # We are using the last and the second to last points to calculate the slope
-    dt = times[end] - times[end-2]
+  dy = observations[end] - observations[end-2] # We are using the last and the second to last points to calculate the slope
+  dt = times[end] - times[end-2]
 
-    return dy/dt # The return function indicates what should be the result of calling the function
+  return dy / dt # The return function indicates what should be the result of calling the function
 
 end
 
@@ -32,12 +32,13 @@ terminal_slope(times, observations)
 pwd() # Prints the present working directory
 
 ## Compact function assignment
-geo_mean(values) = prod(values)^(1/length(values)) # name(args) = result
+geo_mean(values) = prod(values)^(1 / length(values)) # name(args) = result
 
 geo_mean(1:10)
 geo_mean(rand(10))
 
-terminal_slope(times, observations) = (observations[end] - observations[end-2]) / (times[end] - times[end-2])
+terminal_slope(times, observations) =
+  (observations[end] - observations[end-2]) / (times[end] - times[end-2])
 
 terminal_slope(times, observations)
 
@@ -46,13 +47,13 @@ using Statistics
 
 function summary_statistics(values)
 
-    min = minimum(values)
-    max = maximum(values)
-    q1 = quantile(values, 0.25)
-    q2 = quantile(values, 0.5)
-    q3 = quantile(values, 0.75)
+  min = minimum(values)
+  max = maximum(values)
+  q1 = quantile(values, 0.25)
+  q2 = quantile(values, 0.5)
+  q3 = quantile(values, 0.75)
 
-    return min, max, q1, q2, q3  # Return multiple values with return1, return2, return3, ...
+  return min, max, q1, q2, q3  # Return multiple values with return1, return2, return3, ...
 end
 
 summary = summary_statistics(1:10) # We get a Tuple

--- a/03-functions/02-advanced.jl
+++ b/03-functions/02-advanced.jl
@@ -8,10 +8,10 @@ last and the third to last points
 """
 function terminal_slope(times, observations)
 
-    dy = observations[end] - observations[end-2] # We are using the last and the second to last points to calculate the slope
-    dt = times[end] - times[end-2]
+  dy = observations[end] - observations[end-2] # We are using the last and the second to last points to calculate the slope
+  dt = times[end] - times[end-2]
 
-    return dy/dt
+  return dy / dt
 
 end
 
@@ -27,15 +27,15 @@ integration using the [trapezoidal rule](https://en.wikipedia.org/wiki/Trapezoid
 """
 function AUC(times::Vector, observations::Vector)
 
-    auc = 0
+  auc = 0
 
-    for i in 1:length(times)-1
+  for i = 1:length(times)-1
 
-        auc += (observations[i] + observations[i+1])*(times[i+1] - times[i]) / 2
+    auc += (observations[i] + observations[i+1]) * (times[i+1] - times[i]) / 2
 
-    end
+  end
 
-    return auc
+  return auc
 
 end
 
@@ -45,15 +45,15 @@ typeof(AUC(times, observations)) # We get a Float64 by default, but we could enf
 
 function AUC(times::Vector, observations::Vector)::Float64
 
-    auc = 0
+  auc = 0
 
-    for i in 1:length(times)-1
+  for i = 1:length(times)-1
 
-        auc += (observations[i] + observations[i+1])*(times[i+1] - times[i]) / 2
+    auc += (observations[i] + observations[i+1]) * (times[i+1] - times[i]) / 2
 
-    end
+  end
 
-    return auc
+  return auc
 
 end
 
@@ -61,32 +61,32 @@ AUC(times, observations)
 typeof(AUC(times, observations))
 
 # Default values
-function terminal_slope(observations, times=[0, 1, 2, 4, 8, 12, 24]) # We define standard values for the time points
+function terminal_slope(observations, times = [0, 1, 2, 4, 8, 12, 24]) # We define standard values for the time points
 
-    dy = observations[end] - observations[end-2]
-    dt = times[end] - times[end-2]
+  dy = observations[end] - observations[end-2]
+  dt = times[end] - times[end-2]
 
-    return dy/dt
+  return dy / dt
 
 end
 
 terminal_slope(observations) # We don't need to specify the time points because we provided a default value
-terminal_slope(observations, times/24) # We can always overwrite the default values if we want to
+terminal_slope(observations, times / 24) # We can always overwrite the default values if we want to
 
 # Keyword arguments
 ## Arguments that can be specified through names instead of positions
-function terminal_slope(times, observations; npoints=2) # Now we can specify how far back we want to go to calculate the slope
+function terminal_slope(times, observations; npoints = 2) # Now we can specify how far back we want to go to calculate the slope
 
-    dy = observations[end] - observations[end-npoints]
-    dt = times[end] - times[end-npoints]
+  dy = observations[end] - observations[end-npoints]
+  dt = times[end] - times[end-npoints]
 
-    return dy/dt
+  return dy / dt
 
 end
 
 terminal_slope(times, observations, 1) # Doesn't work
-terminal_slope(times, observations; npoints=1) # Keyword arguments are separated from the rest by ;
-terminal_slope(times, observations, npoints=1) # Also works, but using ; is recommended
+terminal_slope(times, observations; npoints = 1) # Keyword arguments are separated from the rest by ;
+terminal_slope(times, observations, npoints = 1) # Also works, but using ; is recommended
 
 # Anonymous functions
 """
@@ -94,19 +94,19 @@ This function takes a function and applies it to
 a vector of numbers
 """
 function apply(func, vector) # Watch out: you cannot use "function" as an argument name
-    new_vector = [func(element) for element in vector] # Array comprehension
-    return new_vector
+  new_vector = [func(element) for element in vector] # Array comprehension
+  return new_vector
 end
 
 ## Let's change the time units to days
-days(hours) = hours/24
+days(hours) = hours / 24
 apply(days, times)
 
 ## Now for minutes
-minutes(hours) = hours*60
+minutes(hours) = hours * 60
 apply(minutes, times)
 
 ## In those cases, we don't really care about the name of the function.
 ## This is a good use case for anonymous functions
-apply(i -> i/24, times) # Syntax is arg -> f(arg)
-apply(i -> i*60, times)
+apply(i -> i / 24, times) # Syntax is arg -> f(arg)
+apply(i -> i * 60, times)

--- a/03-functions/03-dispatch.jl
+++ b/03-functions/03-dispatch.jl
@@ -5,15 +5,15 @@ include("02-advanced.jl")
 # We already saw how to constrain argument types
 function AUC(times::Vector, observations::Vector)
 
-    auc = 0
+  auc = 0
 
-    for i in 1:length(times)-1
+  for i = 1:length(times)-1
 
-        auc += (observations[i] + observations[i+1])*(times[i+1] - times[i]) / 2
+    auc += (observations[i] + observations[i+1]) * (times[i+1] - times[i]) / 2
 
-    end
+  end
 
-    return auc
+  return auc
 
 end
 
@@ -22,34 +22,34 @@ AUC(times, observations)
 
 # Suppose we would also like to have something that calculates the AUC for a population
 population = Dict(
-    "SUBJ-1" => [0.01, 112, 224, 220, 143, 109, 57],
-    "SUBJ-2" => [0.01, 78, 168, 148, 119, 97, 48],
-    "SUBJ-3" => [0.01, 54, 100, 91, 73, 56, 32]
+  "SUBJ-1" => [0.01, 112, 224, 220, 143, 109, 57],
+  "SUBJ-2" => [0.01, 78, 168, 148, 119, 97, 48],
+  "SUBJ-3" => [0.01, 54, 100, 91, 73, 56, 32],
 )
 
 AUC(times, population) # Of course, our function won't work here
 
 function AUC_pop(times::Vector, population::Dict)
 
-    auc_values = Dict() # We are creating an empty dictionary to add the results
+  auc_values = Dict() # We are creating an empty dictionary to add the results
 
-    for subject in population
+  for subject in population
 
-        auc = 0
-        observations = subject.second # Get the observations for a given subject
+    auc = 0
+    observations = subject.second # Get the observations for a given subject
 
-        for i in 1:length(times)-1
+    for i = 1:length(times)-1
 
-            auc += (observations[i] + observations[i+1])*(times[i+1] - times[i]) / 2
-
-        end
-
-        subject_id = subject.first
-        auc_values[subject_id] = auc
+      auc += (observations[i] + observations[i+1]) * (times[i+1] - times[i]) / 2
 
     end
 
-    return auc_values
+    subject_id = subject.first
+    auc_values[subject_id] = auc
+
+  end
+
+  return auc_values
 
 end
 
@@ -59,25 +59,25 @@ AUC_pop(times, population)
 ## Multiple dispatch can solve that
 function AUC(times::Vector, population::Dict) # We use the same name, but different argument types
 
-    auc_values = Dict() # We are creating an empty dictionary to add the results
+  auc_values = Dict() # We are creating an empty dictionary to add the results
 
-    for subject in population
+  for subject in population
 
-        auc = 0
-        observations = subject.second # Get the observations for a given subject
+    auc = 0
+    observations = subject.second # Get the observations for a given subject
 
-        for i in 1:length(times)-1
+    for i = 1:length(times)-1
 
-            auc += (observations[i] + observations[i+1])*(times[i+1] - times[i]) / 2
-
-        end
-
-        subject_id = subject.first
-        auc_values[subject_id] = auc
+      auc += (observations[i] + observations[i+1]) * (times[i+1] - times[i]) / 2
 
     end
 
-    return auc_values
+    subject_id = subject.first
+    auc_values[subject_id] = auc
+
+  end
+
+  return auc_values
 
 end
 

--- a/04-functional_programming/01-apply.jl
+++ b/04-functional_programming/01-apply.jl
@@ -1,23 +1,23 @@
 # Functional programming is about creating your programs by applying and composing functions
 
 """
-A function that calculates the terminal slope using the last and 
+A function that calculates the terminal slope using the last and
 the third to last observations
 """
-function terminal_slope(observations; time=[0, 1, 2, 4, 8, 12, 24]) # We are setting default time values
+function terminal_slope(observations; time = [0, 1, 2, 4, 8, 12, 24]) # We are setting default time values
 
-    dy = observations[end] - observations[end-2]
-    dx = time[end] - time[end-2]
+  dy = observations[end] - observations[end-2]
+  dx = time[end] - time[end-2]
 
-    return dy/dx
+  return dy / dx
 
 end
 
 # Now let's suppose we wan't to calculate the terminal slope for a group of subjects
 population = Dict(
-    "SUBJ-1" => [0.01, 112, 224, 220, 143, 109, 57],
-    "SUBJ-2" => [0.01, 78, 168, 148, 119, 97, 48],
-    "SUBJ-3" => [0.01, 54, 100, 91, 73, 56, 32]
+  "SUBJ-1" => [0.01, 112, 224, 220, 143, 109, 57],
+  "SUBJ-2" => [0.01, 78, 168, 148, 119, 97, 48],
+  "SUBJ-3" => [0.01, 54, 100, 91, 73, 56, 32],
 )
 
 ## We could do an array comprehension

--- a/04-functional_programming/02-reduce.jl
+++ b/04-functional_programming/02-reduce.jl
@@ -19,14 +19,14 @@ Simple function to calculate the AUC  with reduce
 using the trapezoidal rule (https://en.wikipedia.org/wiki/Trapezoidal_rule)
 """
 function AUC(accumulated, i)
-    
-    trapz_area = (obs[i] + obs[i+1])*(times[i+1] - times[i]) / 2
 
-    return accumulated + trapz_area
+  trapz_area = (obs[i] + obs[i+1]) * (times[i+1] - times[i]) / 2
+
+  return accumulated + trapz_area
 
 end
 
-reduce(AUC, 1:length(obs)-1; init=0) # Need to set the accumulated value to 0 at the start
+reduce(AUC, 1:length(obs)-1; init = 0) # Need to set the accumulated value to 0 at the start
 
 ## Common use case: reduce + map
 using Statistics

--- a/04-functional_programming/03-filter.jl
+++ b/04-functional_programming/03-filter.jl
@@ -8,18 +8,7 @@ filter(!iseven, x) # Get all odd numbers (negate iseven)
 filter(isodd, x) # Get all odd numbers (isodd(x) = true)
 
 ## Common use case: remove missing values
-obs = [
-    missing,
-    0.067,
-    110,
-    220,
-    220,
-    missing,
-    110,
-    58,
-    missing,
-    76
-]
+obs = [missing, 0.067, 110, 220, 220, missing, 110, 58, missing, 76]
 
 filter(i -> i != missing, obs) # Doesn't work, we need to use the ismissing function
 filter(!ismissing, obs) # Negate ismissing to get all the values that are not missing

--- a/04-functional_programming/04-composition.jl
+++ b/04-functional_programming/04-composition.jl
@@ -11,9 +11,9 @@ my_operation(-2)
 ## More complex example: geometric mean
 x = 1:10
 
-exp(sum(log.(x))/length(x))
+exp(sum(log.(x)) / length(x))
 
-geometric_mean = (exp ∘ (i -> sum(i)/length(i)) ∘ (i -> log.(i))) # Watch out: wrap anonymous functions around parenthesis
+geometric_mean = (exp ∘ (i -> sum(i) / length(i)) ∘ (i -> log.(i))) # Watch out: wrap anonymous functions around parenthesis
 geometric_mean(x)
 
 using StatsBase
@@ -23,5 +23,5 @@ geomean(x) # Check our results
 -2 |> abs |> sqrt |> exp # Opposite order from composition
 
 ## Geometric mean
-x |> (i -> log.(i)) |> (i -> sum(i)/length(i)) |> exp
-x .|> log |> (i -> sum(i)/length(i)) |> exp # You can vectorize the piping operator (.|>)
+x |> (i -> log.(i)) |> (i -> sum(i) / length(i)) |> exp
+x .|> log |> (i -> sum(i) / length(i)) |> exp # You can vectorize the piping operator (.|>)


### PR DESCRIPTION
Added the `.JuliaFormatter.toml` file and applied the formatting according to it.

This one required some manual intervention as it was causing some problems:

- If we try to run `format(".")` we get an error related to `01-variables/03-strings.jl`, which looks like it is related to the `'Hello, world!'` example (to showcase an incorrect use of `'`). I was able to format that file and the rest by commenting that line out, running `format(".")` and then uncommenting the line. The same happens if we try to format the [Julia basics](https://tutorials.pumas.ai/html/DataWranglingInJulia/02-julia-syntax.html) tutorial. I couldn't think of a way to fix it, so I created an [issue in `JuliaFormatter.jl's repository`](https://github.com/domluna/JuliaFormatter.jl/issues/752)
- There are a couple of corrections which I am not sure if we want to apply. I left some review comments on them